### PR TITLE
Support Let's Encrypt certificates provided for freeboxos.fr domains

### DIFF
--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -54,9 +54,13 @@ class Freepybox:
         if not self._is_app_desc_valid(self.app_desc):
             raise InvalidTokenError('invalid application descriptor')
 
-        cert_path = os.path.join(os.path.dirname(__file__), 'freebox_root_ca.pem')
+        if host.endswith('.freeboxos.fr'):
+            # freeboxos.fr certificates are provided by Let's Encrypt, no need to provide custom certificate
+            ssl_ctx = ssl.create_default_context()
+        else:
+            cert_path = os.path.join(os.path.dirname(__file__), 'freebox_root_ca.pem')
+            ssl_ctx = ssl.create_default_context(cafile=cert_path)
 
-        ssl_ctx = ssl.create_default_context(cafile=cert_path)
         conn = aiohttp.TCPConnector(ssl_context=ssl_ctx)
         self.session = aiohttp.ClientSession(connector=conn)
 


### PR DESCRIPTION
This official way to get HTTPS support without providing a custom CA certificate when connecting to the Freebox API is to setup a custom freeboxos.fr subdomain: https://dev.freebox.fr/bugs/task/19630

Without this change, accessing mycustomdomain.freeboxos.fr:54321 from Home Assistant fails with the following error:

```
home-assistant   | 2018-06-17 13:51:45 ERROR (MainThread) [homeassistant.core] Error doing job: <uvloop.loop.SSLProtocol object at 0x7f15e825c7f0>: SSL handshake failed
home-assistant   | Traceback (most recent call last):
home-assistant   |   File "uvloop/sslproto.pyx", line 592, in uvloop.loop.SSLProtocol._on_handshake_complete
home-assistant   |   File "uvloop/sslproto.pyx", line 171, in uvloop.loop._SSLPipe.feed_ssldata
home-assistant   |   File "/usr/local/lib/python3.6/ssl.py", line 689, in do_handshake
home-assistant   |     self._sslobj.do_handshake()
home-assistant   | ssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:833)
home-assistant   | 2018-06-17 13:51:45 ERROR (MainThread) [homeassistant.core] Error doing job: <uvloop.loop.SSLProtocol object at 0x7f15e825c7f0>: SSL error errno:1 reason: CERTIFICATE_VERIFY_FAILED
home-assistant   | Traceback (most recent call last):
home-assistant   |   File "uvloop/sslproto.pyx", line 496, in uvloop.loop.SSLProtocol.data_received
home-assistant   |   File "uvloop/sslproto.pyx", line 204, in uvloop.loop._SSLPipe.feed_ssldata
home-assistant   |   File "uvloop/sslproto.pyx", line 171, in uvloop.loop._SSLPipe.feed_ssldata
home-assistant   |   File "/usr/local/lib/python3.6/ssl.py", line 689, in do_handshake
home-assistant   |     self._sslobj.do_handshake()
home-assistant   | ssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:833)
home-assistant   | 2018-06-17 13:51:45 ERROR (MainThread) [homeassistant.components.device_tracker] Error setting up platform freebox
home-assistant   | Traceback (most recent call last):
home-assistant   |   File "/usr/local/lib/python3.6/site-packages/aiohttp/connector.py", line 822, in _wrap_create_connection
home-assistant   |     return await self._loop.create_connection(*args, **kwargs)
home-assistant   |   File "uvloop/loop.pyx", line 1811, in create_connection
home-assistant   |   File "uvloop/loop.pyx", line 1789, in uvloop.loop.Loop.create_connection
home-assistant   |   File "uvloop/handles/tcp.pyx", line 178, in uvloop.loop.TCPTransport.connect
home-assistant   |   File "uvloop/handles/tcp.pyx", line 200, in uvloop.loop._TCPConnectRequest.connect
home-assistant   | OSError: [Errno 101] Network is unreachable
home-assistant   |
home-assistant   | The above exception was the direct cause of the following exception:
home-assistant   |
home-assistant   | Traceback (most recent call last):
home-assistant   |   File "/usr/src/app/homeassistant/components/device_tracker/__init__.py", line 179, in async_setup_platform
home-assistant   |     hass, p_config, tracker.async_see, disc_info)
home-assistant   |   File "/usr/src/app/homeassistant/components/device_tracker/freebox.py", line 51, in async_setup_scanner
home-assistant   |     await scanner.async_start(hass, interval)
home-assistant   |   File "/usr/src/app/homeassistant/components/device_tracker/freebox.py", line 96, in async_start
home-assistant   |     await self.async_update_info()
home-assistant   |   File "/usr/src/app/homeassistant/components/device_tracker/freebox.py", line 106, in async_update_info
home-assistant   |     await self.fbx.open(self.host, self.port)
home-assistant   |   File "/usr/local/lib/python3.6/site-packages/aiofreepybox/aiofreepybox.py", line 63, in open
home-assistant   |     self._access = await self._get_freebox_access(host, port, self.api_version, self.token_file, self.app_desc, self.timeout)
home-assistant   |   File "/usr/local/lib/python3.6/site-packages/aiofreepybox/aiofreepybox.py", line 100, in _get_freebox_access
home-assistant   |     app_token, track_id = await self._get_app_token(base_url, app_desc, timeout)
home-assistant   |   File "/usr/local/lib/python3.6/site-packages/aiofreepybox/aiofreepybox.py", line 164, in _get_app_token
home-assistant   |     r = await self.session.post(url, data=data, timeout=timeout)
home-assistant   |   File "/usr/local/lib/python3.6/site-packages/aiohttp/client.py", line 366, in _request
home-assistant   |     timeout=timeout
home-assistant   |   File "/usr/local/lib/python3.6/site-packages/aiohttp/connector.py", line 445, in connect
home-assistant   |     proto = await self._create_connection(req, traces, timeout)
home-assistant   |   File "/usr/local/lib/python3.6/site-packages/aiohttp/connector.py", line 757, in _create_connection
home-assistant   |     req, traces, timeout)
home-assistant   |   File "/usr/local/lib/python3.6/site-packages/aiohttp/connector.py", line 879, in _create_direct_connection
home-assistant   |     raise last_exc
home-assistant   |   File "/usr/local/lib/python3.6/site-packages/aiohttp/connector.py", line 862, in _create_direct_connection
home-assistant   |     req=req, client_error=client_error)
home-assistant   |   File "/usr/local/lib/python3.6/site-packages/aiohttp/connector.py", line 829, in _wrap_create_connection
home-assistant   |     raise client_error(req.connection_key, exc) from exc
home-assistant   | aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host mycustomdomain.freeboxos.fr:54321 ssl:None [Network is unreachable]
```

Note: using a custom domain does not work with discovery and requires adding configuration:

```
device_tracker:
  - platform: freebox
    host: mycustomdomain.freeboxos.fr
    port: 54321
```

Tested with Home Assistant 0.72.0b2 (homeassistant/home-assistant:0.72.0b2 docker image)