### PR TITLE
Create new var to write in the token file

### DIFF
--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -181,8 +181,7 @@ class Freepybox:
         """
         Store the application token in g_app_auth_file file
         """
-        d = {k: app_desc[k] for k in ('app_id', 'app_name', 'app_version', 'device_name')}
-        d.update({'app_token': app_token, 'track_id': track_id})
+        d = {**app_desc, 'app_token': app_token, 'track_id': track_id}
 
         with open(file, 'w') as f:
             json.dump(d, f)

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -181,7 +181,7 @@ class Freepybox:
         """
         Store the application token in g_app_auth_file file
         """
-        d = app_desc
+        d = {k: app_desc[k] for k in ('app_id', 'app_name', 'app_version', 'device_name')}
         d.update({'app_token': app_token, 'track_id': track_id})
 
         with open(file, 'w') as f:


### PR DESCRIPTION
Leave app_desc untouched before writing in token file (function  _writefile_app_token) to avoid infinite loop of token query with Home Assistant.
See issue home-assistant/home-assistant#16934