### PR TITLE
Automatic refresh of the session token

### DIFF
--- a/aiofreepybox/access.py
+++ b/aiofreepybox/access.py
@@ -1,22 +1,88 @@
+import hmac
 import json
+import logging
 from urllib.parse import urljoin
 from aiofreepybox.exceptions import *
 
+logger = logging.getLogger(__name__)
 
 class Access:
-    def __init__(self, session, base_url, session_token, http_timeout):
+    def __init__(self, session, base_url, app_token, app_id, http_timeout):
         self.session = session
-        self.header = {'X-Fbx-App-Auth': session_token}
         self.base_url = base_url
+        self.app_token = app_token
+        self.app_id = app_id
         self.timeout = http_timeout
+        self.session_token = None
+
+    async def _get_challenge(self, base_url, timeout=10):
+        '''
+        Return challenge from freebox API
+        '''
+        url = urljoin(base_url, 'login')
+        r = await self.session.get(url, timeout=timeout)
+        resp = await r.json()
+
+        # raise exception if resp.success != True
+        if not resp.get('success'):
+            raise AuthorizationError('Getting challenge failed (APIResponse: {0})'
+                                     .format(json.dumps(resp)))
+
+        return resp['result']['challenge']
+
+    async def _get_session_token(self, base_url, app_token, app_id, timeout=10):
+        """
+        Get session token from freebox.
+        Returns (session_token, session_permissions)
+        """
+        # Get challenge from API
+        challenge = await self._get_challenge(base_url, timeout)
+
+        # Hash app_token with chalenge key to get the password
+        h = hmac.new(app_token.encode(), challenge.encode(), 'sha1')
+        password = h.hexdigest()
+
+        url = urljoin(base_url, 'login/session/')
+        data = json.dumps({'app_id': app_id, 'password': password})
+        r = await self.session.post(url, data=data, timeout=timeout)
+        resp = await r.json()
+
+        # raise exception if resp.success != True
+        if not resp.get('success'):
+            raise AuthorizationError('Starting session failed (APIResponse: {0})'
+                                     .format(json.dumps(resp)))
+
+        session_token = resp.get('result').get('session_token')
+        session_permissions = resp.get('result').get('permissions')
+
+        return(session_token, session_permissions)
+
+    async def _refresh_session_token(self):
+        # Get token for the current session
+        session_token, session_permissions = await self._get_session_token(
+            self.base_url,
+            self.app_token,
+            self.app_id,
+            self.timeout)
+
+        logger.info('Session opened')
+        logger.info('Permissions: ' + str(session_permissions))
+        self.session_token = session_token
 
     async def get(self, end_url):
         '''
         Send get request and return results
         '''
+        if not self.session_token:
+            await self._refresh_session_token()
         url = urljoin(self.base_url, end_url)
-        r = await self.session.get(url, headers=self.header, timeout=self.timeout)
+        r = await self.session.get(url, headers={'X-Fbx-App-Auth': self.session_token}, timeout=self.timeout)
         resp = await r.json()
+
+        if resp.get('error_code') == 'auth_required':
+            await self._refresh_session_token()
+            r = await self.session.get(url, headers={'X-Fbx-App-Auth': self.session_token}, timeout=self.timeout)
+            resp = await r.json()
 
         if not resp['success']:
             raise HttpRequestError('GET request failed (APIResponse: {0})'
@@ -28,11 +94,17 @@ class Access:
         '''
         Send post request and return results
         '''
+        if not self.session_token:
+            await self._refresh_session_token()
         url = urljoin(self.base_url, end_url)
         data = json.dumps(payload) if payload is not None else None
-        r = await self.session.post(url, headers=self.header, data=data, timeout=self.timeout)
+        r = await self.session.post(url, headers={'X-Fbx-App-Auth': self.session_token}, data=data, timeout=self.timeout)
         resp = await r.json()
 
+        if resp.get('error_code') == 'auth_required':
+            await self._refresh_session_token()
+            r = await self.session.post(url, headers={'X-Fbx-App-Auth': self.session_token}, data=data, timeout=self.timeout)
+            resp = await r.json()
         if not resp['success']:
             raise HttpRequestError('POST request failed (APIResponse: {0})'
                                    .format(json.dumps(resp)))
@@ -43,11 +115,17 @@ class Access:
         '''
         Send post request and return results
         '''
+        if not self.session_token:
+            await self._refresh_session_token()
         url = urljoin(self.base_url, end_url)
         data = json.dumps(payload) if payload is not None else None
         r = await self.session.put(url, headers=self.header, data=data, timeout=self.timeout)
         resp = await r.json()
 
+        if resp.get('error_code') == 'auth_required':
+            await self._refresh_session_token()
+            r = await self.session.put(url, headers={'X-Fbx-App-Auth': self.session_token}, data=data, timeout=self.timeout)
+            resp = await r.json()
         if not resp['success']:
             raise HttpRequestError('PUT request failed (APIResponse: {0})'
                                    .format(json.dumps(resp)))

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -59,7 +59,7 @@ class Freepybox:
         ssl_ctx.load_verify_locations(cafile=cert_path)
 
         conn = aiohttp.TCPConnector(ssl_context=ssl_ctx)
-        self.session = aiohttp.ClientSession(connector=conn, raise_for_status=True)
+        self.session = aiohttp.ClientSession(connector=conn)
 
         self._access = await self._get_freebox_access(host, port, self.api_version, self.token_file, self.app_desc, self.timeout)
 

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -1,5 +1,4 @@
 import asyncio
-import hmac
 import ipaddress
 import os
 import json
@@ -127,17 +126,10 @@ class Freepybox:
 
             # Store application token in file
             self._writefile_app_token(app_token, track_id, app_desc, token_file)
-            logger.info('Application token file was generated : {0}'.format(token_file))
-
-
-        # Get token for the current session
-        session_token, session_permissions = await self._get_session_token(base_url, app_token, app_desc['app_id'], timeout)
-
-        logger.info('Session opened')
-        logger.info('Permissions: ' + str(session_permissions))
+            logger.info('Application token file was generated: {0}'.format(token_file))
 
         # Create freebox http access module
-        fbx_access = Access(self.session, base_url, session_token, timeout)
+        fbx_access = Access(self.session, base_url, app_token, app_desc['app_id'], timeout)
 
         return fbx_access
 
@@ -201,48 +193,6 @@ class Freepybox:
 
         except FileNotFoundError:
             return (None, None, None)
-
-    async def _get_session_token(self, base_url, app_token, app_id, timeout=10):
-        """
-        Get session token from freebox.
-        Returns (session_token, session_permissions)
-        """
-        # Get challenge from API
-        challenge = await self._get_challenge(base_url, timeout)
-
-        # Hash app_token with chalenge key to get the password
-        h = hmac.new(app_token.encode(), challenge.encode(), 'sha1')
-        password = h.hexdigest()
-
-        url = urljoin(base_url, 'login/session/')
-        data = json.dumps({'app_id': app_id, 'password': password})
-        r = await self.session.post(url, data=data, timeout=timeout)
-        resp = await r.json()
-
-        # raise exception if resp.success != True
-        if not resp.get('success'):
-            raise AuthorizationError('Starting session failed (APIResponse: {0})'
-                                     .format(json.dumps(resp)))
-
-        session_token = resp.get('result').get('session_token')
-        session_permissions = resp.get('result').get('permissions')
-
-        return(session_token, session_permissions)
-
-    async def _get_challenge(self, base_url, timeout=10):
-        '''
-        Return challenge from freebox API
-        '''
-        url = urljoin(base_url, 'login')
-        r = await self.session.get(url, timeout=timeout)
-        resp = await r.json()
-
-        # raise exception if resp.success != True
-        if not resp.get('success'):
-            raise AuthorizationError('Getting challenge failed (APIResponse: {0})'
-                                     .format(json.dumps(resp)))
-
-        return resp['result']['challenge']
 
     def _get_base_url(self, host, port, freebox_api_version):
         '''


### PR DESCRIPTION
This PR adds automatic refresh of the session token. The session token is requested when a request fails with an authentication error.

Should fix #7 